### PR TITLE
Fix/bug fix 3

### DIFF
--- a/lib/features/bluetooth/platform/bluetooth_platform.dart
+++ b/lib/features/bluetooth/platform/bluetooth_platform.dart
@@ -214,12 +214,37 @@ class BluetoothPlatform {
     }
   }
 
+  // Retry getting device name
+  static Future<BluetoothDevice?> retryGetDeviceName() async {
+    try {
+      final Map<dynamic, dynamic>? result =
+          await platform.invokeMethod('retryGetDeviceName');
+      if (result != null) {
+        return BluetoothDevice.fromMap(result);
+      }
+      return null;
+    } on PlatformException catch (e) {
+      print("Failed to retry getting device name: ${e.message}");
+      return null;
+    }
+  }
+
   // Get battery level of connected device
   static Future<int?> getBatteryLevel() async {
     try {
       return await platform.invokeMethod('getBatteryLevel');
     } on PlatformException catch (e) {
       print("Failed to get battery level: ${e.message}");
+      return null;
+    }
+  }
+
+  // Retry getting battery level
+  static Future<int?> retryGetBatteryLevel() async {
+    try {
+      return await platform.invokeMethod('retryGetBatteryLevel');
+    } on PlatformException catch (e) {
+      print("Failed to retry getting battery level: ${e.message}");
       return null;
     }
   }

--- a/lib/features/sound_test/views/screens/test_page.dart
+++ b/lib/features/sound_test/views/screens/test_page.dart
@@ -135,7 +135,7 @@ class _TestPageState extends State<TestPage> {
       debugPrint("Error initializing audio: $e");
       if (mounted) {
         _showCustomToast(context,
-            'Error setting up audio. Please check your earphones connection.');
+            AppLocalizations.of(context).translate('error_setting_up_audio'));
       }
     }
   }
@@ -424,7 +424,8 @@ class _TestPageState extends State<TestPage> {
   }
 
   void _showSaveConfirmationDialog(BuildContext context) {
-    _showCustomToast(context, 'Value recorded');
+    _showCustomToast(
+        context, AppLocalizations.of(context).translate('value_recorded'));
   }
 
   void _showCustomToast(BuildContext context, String message) {
@@ -578,7 +579,8 @@ class _TestPageState extends State<TestPage> {
     } catch (e) {
       debugPrint("AUDIO DEBUG: Error playing frequency: $e");
       if (mounted) {
-        _showCustomToast(context, 'Error playing audio: $e');
+        _showCustomToast(context,
+            AppLocalizations.of(context).translate('error_playing_audio'));
       }
     }
   }
@@ -667,7 +669,7 @@ class _TestPageState extends State<TestPage> {
 
         // Show message about confirmation phase - keeping this toast as it's user guidance
         _showCustomToast(context,
-            'Press "I can hear it" if you can hear the tone to confirm your threshold.');
+            AppLocalizations.of(context).translate('press_hear_to_confirm'));
 
         // Go back up 5dB
         incrementFrequencyVolume(frequency_player);
@@ -698,8 +700,20 @@ class _TestPageState extends State<TestPage> {
         double dbSPLValue = convertVolumeToDBSPL(current_volume);
         double dbHLValue = convertDBSPLtoDBHL(dbSPLValue, frequency);
 
-        _showCustomToast(context,
-            'Threshold for ${current_ear == "L" ? "Left" : "Right"} ear at ${frequencyText}Hz: ${dbHLValue.toStringAsFixed(1)} dB HL (${dbSPLValue.toStringAsFixed(1)} dB SPL)');
+        // Translate left or right ear
+        final String earText = current_ear == "L"
+            ? AppLocalizations.of(context).translate('left')
+            : AppLocalizations.of(context).translate('right');
+
+        // Format the threshold message with the translated template
+        final String thresholdMessage = AppLocalizations.of(context)
+            .translate('threshold_for_ear')
+            .replaceAll('{ear}', earText)
+            .replaceAll('{frequency}', frequencyText)
+            .replaceAll('{db_hl}', dbHLValue.toStringAsFixed(1))
+            .replaceAll('{db_spl}', dbSPLValue.toStringAsFixed(1));
+
+        _showCustomToast(context, thresholdMessage);
 
         // Stop current tone
         stopSound();
@@ -745,8 +759,8 @@ class _TestPageState extends State<TestPage> {
       await testPlayer.play(AssetSource('audio/1000Hz.wav'));
       debugPrint("TEST AUDIO: Play method completed");
 
-      _showCustomToast(
-          context, "Testing sound playback - you should hear a 1kHz tone");
+      _showCustomToast(context,
+          AppLocalizations.of(context).translate('testing_sound_playback'));
 
       // Clean up after 3 seconds
       await Future.delayed(const Duration(seconds: 3));
@@ -754,7 +768,8 @@ class _TestPageState extends State<TestPage> {
       await testPlayer.dispose();
     } catch (e) {
       debugPrint("TEST AUDIO: Error in test play: $e");
-      _showCustomToast(context, "Error testing audio: $e");
+      _showCustomToast(context,
+          AppLocalizations.of(context).translate('error_testing_audio'));
     }
   }
 
@@ -1598,8 +1613,10 @@ class _TestPageState extends State<TestPage> {
       if (!isConnected) {
         debugPrint("WARNING: No Bluetooth headset connected!");
         if (mounted) {
-          _showCustomToast(context,
-              'Please connect Bluetooth headphones for accurate test results');
+          _showCustomToast(
+              context,
+              AppLocalizations.of(context)
+                  .translate('please_connect_bluetooth'));
         }
       } else {
         debugPrint("Bluetooth headset connected, proceeding with test");

--- a/lib/l10n/translations/en.dart
+++ b/lib/l10n/translations/en.dart
@@ -100,7 +100,7 @@ final Map<String, String> enTranslations = {
   'set_max_volume': 'Set your device volume to maximum.',
   'wear_headphones_properly':
       'Wear your headphones correctly and comfortably so that it completely fits in your ears.',
-  'test_duration_minutes': 'This will take only take ~5 minutes',
+  'test_duration_minutes': 'This will take ~5 minutes',
   'instructions': 'A few instructions before starting the test:',
   'audio_profiles': 'Audio Profiles:',
   'max_profiles': 'You can only have a maximum of 3 audio profiles!',

--- a/lib/l10n/translations/en.dart
+++ b/lib/l10n/translations/en.dart
@@ -191,4 +191,18 @@ final Map<String, String> enTranslations = {
   'demo_reset_message':
       'This will clear all hearing tests and presets. This action cannot be undone.',
   'demo_reset_success': 'App has been reset for demonstration',
+
+  // Hearing test toast notifications
+  'press_hear_to_confirm':
+      'Press "I can hear it" if you can hear the tone to confirm your threshold.',
+  'threshold_for_ear':
+      'Threshold for {ear} ear at {frequency}Hz: {db_hl} dB HL ({db_spl} dB SPL)',
+  'left': 'Left',
+  'right': 'Right',
+  'value_recorded': 'Value recorded',
+  'error_setting_up_audio':
+      'Error setting up audio. Please check your earphones connection.',
+  'please_connect_bluetooth':
+      'Please connect Bluetooth headphones for accurate test results',
+  'error_playing_audio': 'Error playing audio. Please check your headphones.',
 };

--- a/lib/l10n/translations/fr.dart
+++ b/lib/l10n/translations/fr.dart
@@ -200,4 +200,19 @@ final Map<String, String> frTranslations = {
       'Cela effacera tous les tests auditifs et préréglages. Cette action ne peut pas être annulée.',
   'demo_reset_success':
       'L\'application a été réinitialisée pour la démonstration',
+
+  // Hearing test toast notifications
+  'press_hear_to_confirm':
+      'Appuyez sur "Je l\'entends!" si vous entendez le son pour confirmer votre seuil.',
+  'threshold_for_ear':
+      'Seuil pour l\'oreille {ear} à {frequency}Hz: {db_hl} dB HL ({db_spl} dB SPL)',
+  'left': 'Gauche',
+  'right': 'Droite',
+  'value_recorded': 'Valeur enregistrée',
+  'error_setting_up_audio':
+      'Erreur de configuration audio. Veuillez vérifier la connexion de vos écouteurs.',
+  'please_connect_bluetooth':
+      'Veuillez connecter des écouteurs Bluetooth pour des résultats de test précis',
+  'error_playing_audio':
+      'Erreur de lecture audio. Veuillez vérifier vos écouteurs.',
 };


### PR DESCRIPTION
This pull request introduces retry mechanisms for obtaining Bluetooth device information, such as the device name and battery level, and integrates these mechanisms into the app's Bluetooth management logic. The changes add new methods, timers, and retry logic to handle scenarios where initial attempts to fetch this information fail.

### Bluetooth Retry Mechanisms:

* **Retrying Device Name Retrieval**: Added a `retryGetDeviceName` method in both the Android native code (`MainActivity.java`) and the Dart platform interface (`BluetoothPlatform`). This method retries fetching the device name using fallback strategies, including searching bonded devices and connected devices. The retry logic is integrated into the `BluetoothProvider` class with a timer to retry periodically until a valid name is retrieved or a maximum retry count is reached. [[1]](diffhunk://#diff-ee83d43fbeeacae9e1c2ad414375a7827e869d0b5b789771602b8a1053306420R786-R841) [[2]](diffhunk://#diff-54a9e76d48a43c69d74ab54434c0980c4eff6bcfbec6cb29211ac95247ba610fR217-R231) [[3]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR399-R445)

* **Retrying Battery Level Retrieval**: Added a `retryGetBatteryLevel` method in both the Android native code (`MainActivity.java`) and the Dart platform interface (`BluetoothPlatform`). This method retries fetching the battery level using multiple approaches, such as HFP and GATT, with a timeout for GATT connections. The retry logic is also integrated into the `BluetoothProvider` class with a timer to handle retries until a valid battery level is retrieved or a maximum retry count is reached. [[1]](diffhunk://#diff-ee83d43fbeeacae9e1c2ad414375a7827e869d0b5b789771602b8a1053306420R1168-R1303) [[2]](diffhunk://#diff-54a9e76d48a43c69d74ab54434c0980c4eff6bcfbec6cb29211ac95247ba610fR241-R250) [[3]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR225-R260)

### Integration with BluetoothProvider:

* **Timers for Retry Logic**: Introduced timers (`_nameRetryTimer` and `_batteryRetryTimer`) and counters to manage retry attempts for both device name and battery level. These timers are started when needed and canceled upon success or reaching the maximum retry count. [[1]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR21-R30) [[2]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR202-R214) [[3]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR399-R445)

* **Connection State Handling**: Updated the `checkBluetoothConnection` method in `BluetoothProvider` to start retry timers when the device name is unknown or the battery level is null. Added logic to cancel retry timers when the device disconnects or an error occurs. [[1]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR462-L446) [[2]](diffhunk://#diff-d66331d48bb811b40e4256957ada2de111b3cb4ce3002964881546abbd16205fR588-R593)

These changes improve the robustness of Bluetooth device management by ensuring critical information is retrieved even in cases of initial failure.